### PR TITLE
Cancelling currently loading requests if a new request is made

### DIFF
--- a/where-to-travel/src/main/webapp/script.js
+++ b/where-to-travel/src/main/webapp/script.js
@@ -57,6 +57,7 @@ let focusedPin;
 let homeMarker = null;
 let markers = [];
 
+// Keeps track of most recent search request
 let globalNonce;
 
 // Add gmap js library to head of page


### PR DESCRIPTION
If the user makes a request, and while it is still loading, they change some settings and make a new request, the current implementation still runs both asynchronously. 

To handle this, I create a unique object that is stored locally and globally after every search request, and after any await calls, where a new search request can possibly be handled, I check to see if the global object has changed, meaning a new request has come in, and terminate the current request early in that case.

This idea is from approach #2 at https://dev.to/chromiumdev/cancellable-async-functions-in-javascript-5gp7 