### PR TITLE
Change processing of address to focusout

### DIFF
--- a/where-to-travel/src/main/webapp/index.html
+++ b/where-to-travel/src/main/webapp/index.html
@@ -49,11 +49,10 @@
               <div id="collapseOne" class="collapse show" aria-labelledby="headingOne">
                 <div class="card-header bg-light text-color">
                   <div class="form-group">
-                    <input type="text" class="form-control text-center" placeholder="Enter an address" id="addressInput">
+                    <input type="text" onfocusout="getHomeLocation(true)" class="form-control text-center" placeholder="Enter an address" id="addressInput">
                   </div>
                   <div class="text-center">
                     <button onclick="getHomeLocation(false)" type="button" class="btn btn-secondary">Use My Location</button>
-                    <button onclick="getHomeLocation(true)" type="button" class="btn btn-secondary">Use Address</button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This is a very minor change in how the address field is processed. Instead of requiring the user to press a button after typing in an address, it will automatically be processed after they leave the text field. Use my location button still remains and autopopulates text field with reverse geocoded address.

Let me know which version you prefer!